### PR TITLE
Fix callback config defaults logic in C2 profiles

### DIFF
--- a/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
@@ -102,7 +102,7 @@ func New() Profile {
 
 	// Convert sleep from string to integer
 	i, err := strconv.Atoi(callback_interval)
-	if err != nil {
+	if err == nil {
 		profile.Interval = i
 	} else {
 		profile.Interval = 10
@@ -110,7 +110,7 @@ func New() Profile {
 
 	// Convert jitter from string to integer
 	j, err := strconv.Atoi(callback_jitter)
-	if err != nil {
+	if err == nil {
 		profile.Jitter = j
 	} else {
 		profile.Jitter = 23

--- a/Payload_Type/poseidon/agent_code/pkg/profiles/websocket.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/websocket.go
@@ -87,7 +87,7 @@ func New() Profile {
 
 	// Convert sleep from string to integer
 	i, err := strconv.Atoi(callback_interval)
-	if err != nil {
+	if err == nil {
 		profile.Interval = i
 	} else {
 		profile.Interval = 10
@@ -95,7 +95,7 @@ func New() Profile {
 
 	// Convert jitter from string to integer
 	j, err := strconv.Atoi(callback_jitter)
-	if err != nil {
+	if err == nil {
 		profile.Jitter = j
 	} else {
 		profile.Jitter = 23


### PR DESCRIPTION
I noticed no matter what callback interval and jitter percentage I chose when building a Poseidon payload with an HTTP C2 profile, it would always effectively be 10 seconds with some jitter. It looks like the error handling logic in `http.go` and `websocket.go` need to be flipped. Let me know if these changes need adjustment or if you have any questions 👍 