### PR TITLE
Removed the 'build darwin' statement

### DIFF
--- a/Payload_Type/poseidon/agent_code/persist_launchd/persist_launchd.go
+++ b/Payload_Type/poseidon/agent_code/persist_launchd/persist_launchd.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package persist_launchd
 
 import (


### PR DESCRIPTION
Fixes an issue where the linux build fails because its missing go files for the persist_launchd command.