### PR TITLE
Garble Support for Linux Payloads

### DIFF
--- a/Payload_Type/poseidon/Dockerfile
+++ b/Payload_Type/poseidon/Dockerfile
@@ -1,1 +1,4 @@
 FROM itsafeaturemythic/xgolang_payload:0.1.2
+
+# Download Garble
+RUN go install mvdan.cc/garble@latest

--- a/Payload_Type/poseidon/agent_code/CHANGELOG.MD
+++ b/Payload_Type/poseidon/agent_code/CHANGELOG.MD
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.2 - 2022-05-05
+
+### Added
+
+- Added Garble support for Linux payloads
+
 ## 1.0.1 - 2021-06-23
 
 ### Added


### PR DESCRIPTION
Added support for [Garble](https://github.com/burrowers/garble)

Garble does help significantly obfuscate the payload, but it leaves at least these string indicators behind:

* `GCC: (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0` - From the build container
* `github.com/MythicAgents/poseidon/Payload_Type/poseidon/agent_code/_cgo_gotypes.go`
* `json:"mythic_uuid,omitempty"` - From the `DelegateMessage` structure in [definitions.go](https://github.com/MythicAgents/poseidon/blob/master/Payload_Type/poseidon/agent_code/pkg/utils/structs/definitions.go)

I tested building and executing Garbled Linux payloads, but did not test building and running macOS payloads. In _theory_ nothing was changed for the macOS payloads and everything works like it used to. :crossed_fingers: 

I did not test how the TCP comms are affected, but can go back and do so. 