### PR TITLE
Add support for SSH key as input (sshauth)

### DIFF
--- a/Payload_Type/poseidon/poseidon/agentfunctions/sshauth.go
+++ b/Payload_Type/poseidon/poseidon/agentfunctions/sshauth.go
@@ -91,8 +91,8 @@ You can also use this to execute a specific command on the remote hosts via SSH 
 			},
 			{
 				Name:             "private_key",
-				ModalDisplayName: "Path to Private key on disk",
-				Description:      "Authenticate to the designated hosts using this private key",
+				ModalDisplayName: "Private Key",
+				Description:      "Authenticate to the designated hosts using this private key (key content or path on disk)",
 				ParameterType:    agentstructs.COMMAND_PARAMETER_TYPE_STRING,
 				ParameterGroupInformation: []agentstructs.ParameterGroupInfo{
 					{

--- a/documentation-payload/poseidon/commands/sshauth.md
+++ b/documentation-payload/poseidon/commands/sshauth.md
@@ -33,7 +33,7 @@ SSH to specified host(s) using the designated credentials. You can also use this
 
 #### private_key
 
-- Description: Authenticate to the designated hosts using this private key  
+- Description: Authenticate to the designated hosts using this private key (key content or path on disk) 
 - Required Value: False  
 - Default Value: None  
 


### PR DESCRIPTION
This pull request enhances the SSH authentication functionality by introducing support for private key content to be provided as a string in addition to file paths, improving flexibility in how credentials are provided and removing the requirement for a credential to exist on-disk. It also includes minor updates to documentation and parameter descriptions for clarity.

This handles the change seamlessly, so existing automation around this should remain intact. In this form, you can enter a private key (e.g. `======BEGIN...`) and it will be parsed as a key _or_ you can use the existing functionality of pointing to a path on disk.

Thoughts about a variant of this in comments below :eyes: 