### PR TITLE
Enhance memory management in executeLibrary function

### DIFF
--- a/Payload_Type/poseidon/poseidon/agent_code/execute_library/execute_library_darwin.go
+++ b/Payload_Type/poseidon/poseidon/agent_code/execute_library/execute_library_darwin.go
@@ -39,6 +39,9 @@ func executeLibrary(filePath string, functionName string, args []string) (Darwin
 		}
 	}
 	r := C.executeLibrary(C.CString(filePath), C.CString(functionName), c_argc, cArgv)
+	if r != nil {
+		defer C.free(unsafe.Pointer(r))
+	}
 	res.Message = C.GoString(r)
 	return res, nil
 }

--- a/Payload_Type/poseidon/poseidon/agent_code/execute_library/execute_library_darwin.m
+++ b/Payload_Type/poseidon/poseidon/agent_code/execute_library/execute_library_darwin.m
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 #include "stdio.h"
 #include <dlfcn.h>
+#include <string.h>
+#include <stdlib.h>
 
 char* executeLibrary(char* filePath, char* functionName, int argc, char** argv){
     void* handle = dlopen(filePath, RTLD_NOW);
@@ -11,11 +13,12 @@ char* executeLibrary(char* filePath, char* functionName, int argc, char** argv){
         char*(*function)(int c, char** argv) = dlsym(handle, functionName);
         if(function != 0){
             char* output = function(argc, argv);
+            char* copiedOutput = output != NULL ? strdup(output) : strdup("");
             dlclose(handle);
-            return output;
+            return copiedOutput;
         }
         dlclose(handle);
-        return "Failed to find function";
+        return strdup("Failed to find function");
     }
-    return "Failed to open dynamic library";
+    return strdup("Failed to open dynamic library");
 }


### PR DESCRIPTION
Copy dylib return strings before `dlclose` so `execute_library` can safely run dylibs that return static `char *` output.

- Added memory cleanup for the returned string in `execute_library_darwin.go` to prevent memory leaks.
- Updated `executeLibrary` implementation in `execute_library_darwin.m` to use `strdup` for returning strings, ensuring proper memory allocation and management for error messages and function outputs.