### PR TITLE
Handle downloads from zero-size pseudo-files

### DIFF
--- a/Payload_Type/poseidon/poseidon/agent_code/pkg/utils/files/sendFile.go
+++ b/Payload_Type/poseidon/poseidon/agent_code/pkg/utils/files/sendFile.go
@@ -17,7 +17,23 @@ import (
 	"github.com/MythicAgents/poseidon/Payload_Type/poseidon/agent_code/pkg/utils/structs"
 )
 
+const maxUnknownFileSize = 10 * FILE_CHUNK_SIZE // Bound buffered reads from pseudo-files and device streams
+
 var SendToMythicChannel = make(chan structs.SendFileToMythicStruct, 10)
+
+func readUnknownSizeFile(file io.ReadSeeker) ([]byte, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, int64(maxUnknownFileSize)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxUnknownFileSize {
+		return nil, fmt.Errorf("file exceeds the %d-byte limit for files with an unknown size", maxUnknownFileSize)
+	}
+	return data, nil
+}
 
 // listenForSendFileToMythicMessages reads from SendToMythicChannel to send file transfer messages to Mythic
 func listenForSendFileToMythicMessages() {
@@ -54,6 +70,18 @@ func sendFileMessagesToMythic(sendFileToMythic structs.SendFileToMythicStruct) {
 			return
 		}
 		size = fi.Size()
+		if size == 0 {
+			data, err := readUnknownSizeFile(sendFileToMythic.File)
+			if err != nil {
+				errResponse := sendFileToMythic.Task.NewResponse()
+				errResponse.SetError(fmt.Sprintf("Error reading file with unknown size: %s", err.Error()))
+				sendFileToMythic.Task.Job.SendResponses <- errResponse
+				sendFileToMythic.FinishedTransfer <- 1
+				return
+			}
+			sendFileToMythic.Data = &data
+			size = int64(len(data))
+		}
 	} else {
 		size = int64(len(*sendFileToMythic.Data))
 	}

--- a/Payload_Type/poseidon/poseidon/agent_code/pkg/utils/files/sendFile_test.go
+++ b/Payload_Type/poseidon/poseidon/agent_code/pkg/utils/files/sendFile_test.go
@@ -1,0 +1,31 @@
+package files
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadUnknownSizeFile(t *testing.T) {
+	expected := []byte("generated\x00content")
+
+	actual, err := readUnknownSizeFile(bytes.NewReader(expected))
+	if err != nil {
+		t.Fatalf("readUnknownSizeFile returned an error: %v", err)
+	}
+	if !bytes.Equal(actual, expected) {
+		t.Fatalf("readUnknownSizeFile returned %q, want %q", actual, expected)
+	}
+}
+
+func TestReadUnknownSizeFileRejectsDataOverLimit(t *testing.T) {
+	data := bytes.NewReader(make([]byte, maxUnknownFileSize+1))
+
+	_, err := readUnknownSizeFile(data)
+	if err == nil {
+		t.Fatal("readUnknownSizeFile accepted data over the limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("readUnknownSizeFile returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- read file-backed transfers that report a zero size before registering them with Mythic
- use the buffered length to calculate the existing asynchronous transfer's chunk count
- cap unknown-size reads at ten Mythic chunks (5,120,000 bytes)
- add focused tests for generated binary content and enforcement of the size limit

## Problem

Files in virtual filesystems can report `st_size == 0` while still producing content when read. For example, `/proc/<pid>/environ` can be readable and non-empty even though `stat()` reports zero bytes.

Poseidon's shared file-transfer path calculated zero chunks from the reported size, registered an empty transfer, and never read the file.

## Implementation

When a file-backed transfer reports zero bytes, the transfer path rewinds and buffers the source before Mythic registration. The resulting byte length is passed through the existing chunk calculation and acknowledged asynchronous transfer loop without changing the wire protocol.

The fallback reads at most ten chunks plus one detection byte. Sources above that limit return an explicit error instead of being truncated or read without a bound. Normal files with a reported nonzero size continue through the existing path unchanged.

Because this is implemented in the shared transfer path, it applies to both `download` and uncompressed `download_bulk`.

## Test plan

- `go test ./pkg/utils/files`
- `go test ./...`
- `git diff --check`

All pass on macOS. Live Linux `/proc` validation remains to be completed.
